### PR TITLE
Revert changes to HumanNameParser class visibility and Name constructor visibility

### DIFF
--- a/src/main/java/org/apache/commons/text/names/HumanNameParser.java
+++ b/src/main/java/org/apache/commons/text/names/HumanNameParser.java
@@ -98,7 +98,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * <p>This class is immutable.</p>
  */
-public class HumanNameParser {
+public final class HumanNameParser {
 
     private final List<String> salutations;
     private final List<String> suffixes;

--- a/src/main/java/org/apache/commons/text/names/Name.java
+++ b/src/main/java/org/apache/commons/text/names/Name.java
@@ -33,7 +33,7 @@ public final class Name {
     private final String lastName;
     private final String suffix;
 
-    public Name(String leadingInitial, String salutation, String firstName, String nickName, String middleName, String lastName, String suffix) {
+    Name(String leadingInitial, String salutation, String firstName, String nickName, String middleName, String lastName, String suffix) {
         this.leadingInitial = leadingInitial;
         this.salutation = salutation;
         this.firstName = firstName;


### PR DESCRIPTION
This PR reverts the changes discussed in the pull request #4 for commons-text.